### PR TITLE
Create Merge Schedule Action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,34 @@
+name: Merge Schedule Action
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+  schedule:
+    # https://crontab.guru/every-hour
+    - cron: '0 * * * *'
+
+jobs:
+  merge_schedule:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Merge Schedule Job
+        uses: gr2m/merge-schedule-action@v2.4.3
+        with:
+          # Merge method to use. Possible values are merge, squash or
+          # rebase. Default is merge.
+          merge_method: merge
+          # Time zone to use. Default is UTC.
+          time_zone: 'America/Chicago'
+          # Require all pull request statuses to be successful before
+          # merging. Default is `false`.
+          require_statuses_success: 'true'
+          # Label to apply to the pull request if the merge fails. Default is
+          # `automerge-fail`.
+          automerge_fail_label: 'merge-schedule-failed'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+            


### PR DESCRIPTION
This is an enhancement or feature.

## Summary

Creates an action that runs every hour. If an MR is ready for merge, this will merge it at the specified time.

## Context

I need a way to merge MRs at a specific time. This is useful for date specific MRs such as Mass schedules for Easter.



/schedule 2024-03-29T15:07:00Z