### PR TITLE
Move to Bookworm and Jekyll 2 devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "Jekyll",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/jekyll:0-bullseye",
+	"image": "mcr.microsoft.com/devcontainers/jekyll:2-bookworm",
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},


### PR DESCRIPTION
## Summary

As part of routine maintenance, I have bumped the Devcontainer json to point to the Jekyll 2 major release with security patches applied. I have moved to use Debian Bookworm as it is the latest stable release.