### PR TITLE
Update confession times

### DIFF
--- a/_data/schedule.yml
+++ b/_data/schedule.yml
@@ -66,6 +66,29 @@ special_masses:
     time: "8:00 AM (English)"
 
 reconciliation:
-  - line: "This page is under construction. Please see the Bulletin for current Reconciliation times."
-  - line: "Also available by appointment by calling the parish office."
-
+  - day: "Monday"
+    times:
+      - time: "11:15 AM - 11:45 AM"
+      - time: "5:15 PM - 5:45 PM"
+  - day: "Tuesday"
+    times:
+      - time: "11:15 AM - 11:45 AM"
+      - time: "6:15 PM - 6:45 PM"
+  - day: "Wednesday"
+    times:
+      - time: "11:15 AM - 11:45 AM"
+      - time: "6:15 PM - 6:45 PM"
+  - day: "Thursday"
+    times:
+      - time: "11:15 AM - 11:45 AM"
+  - day: "Friday"
+    times:
+      - time: "11:15 AM - 11:45 AM"
+      - time: "6:15 PM - 6:45 PM"
+  - day: "Saturday"
+    times:
+      - time: "4:15 PM - 4:45 PM"
+      - time: "6:15 PM - 6:45 PM"
+  - day: "By Appointment"
+    times:
+      - time: "Please call the parish office"

--- a/_information/mass_times.md
+++ b/_information/mass_times.md
@@ -74,9 +74,14 @@ All are welcome to join us for the celebration of the Holy Mass. This schedule i
   </div>
 
   <div class="schedule-card">
-    <h3><span class="icon">🙏</span>Sacrament of Reconciliation</h3>
-    {% for item in site.data.schedule.reconciliation %}
-      <p class="schedule-item">{{ item.line }}</p>
+    <h3 id="reconciliation"><span class="icon">🙏</span>Sacrament of Reconciliation</h3>
+    {% for day in site.data.schedule.reconciliation %}
+      <h4 style="margin-top: {% if forloop.first == false %}1.5rem{% else %}1rem{% endif %};">{{ day.day }}</h4>
+      {% for item in day.times %}
+        <div class="schedule-time">
+          <span class="time">{{ item.time }}</span>
+        </div>
+      {% endfor %}
     {% endfor %}
   </div>
 

--- a/_pages/home.md
+++ b/_pages/home.md
@@ -18,7 +18,7 @@ header:
     - label: "Latest Bulletin"
       url: "/information/bulletins/"
     - label: "Reconciliation"
-      url: "/information/mass_times/"
+      url: "/information/mass_times/#reconciliation"
 ---
 
 


### PR DESCRIPTION
This updates the confession times on the mass_times page.

This updates the link on the home page to take you directly to the reconciliation section of the mass times page so you don't have to scroll.